### PR TITLE
fix Åmot

### DIFF
--- a/src/svenska-stader.csv
+++ b/src/svenska-stader.csv
@@ -1801,7 +1801,7 @@ Zinkgruvan,Askersund,Örebro,58.815435,15.106626
 Åminne,Värnamo,Gotland,57.612497,18.761462
 Åmmeberg,Askersund,Örebro,58.865610,14.999192
 Åmotfors,Eda,Värmland,59.762586,12.362227
-Åmot,Ockelbo,Värmland,59.705202,12.887207
+Åmot,Ockelbo,Gävleborg,60.965613,16.451243
 Åmunnen,Kalmar,Kalmar,56.627696,16.236805
 Åmynnet,Örnsköldsvik,Västernorrland,63.186110,18.530696
 Åmål,Åmål,Västra Götaland,58.969858,12.618004


### PR DESCRIPTION
Fixade Åmot, vilket hade felaktiga koordinater och hade Värmland som angivet län. Åmotsfors, Eda är istället den ort som ligger i Värmland. Åmot i kommunen Ockelbo ligger istället i Gävleborgs län.